### PR TITLE
Render Clickaway listener as a specified element 

### DIFF
--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -23,7 +23,7 @@ describe('ClickAway Listener', () => {
 	});
 	it('it should wrap children around the element type specified', () => {
 		const { container } = render(
-			<ClickAwayListener Container="article" onClickAway={() => null}>
+			<ClickAwayListener as="article" onClickAway={() => null}>
 				hello best
 			</ClickAwayListener>
 		);

--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -3,13 +3,22 @@ import { render, fireEvent } from '@testing-library/react';
 import ClickAwayListener from '../src';
 
 describe('ClickAway Listener', () => {
-	it('should render properly', () => {
-		const { getByText } = render(
+	it('should render properly as "div" if no element is specified', () => {
+		const { container } = render(
 			<ClickAwayListener onClickAway={() => null}>
-				Hello World
+				Hello Default Div
 			</ClickAwayListener>
 		);
-		expect(getByText(/Hello World/i)).toBeTruthy();
+		expect(container.firstElementChild.tagName).toBe('DIV');
+	});
+	
+	it('should be able to get rendered as a specified element', () => {
+		const { container } = render(
+			<ClickAwayListener as="article" onClickAway={() => null}>
+				Hello Article
+			</ClickAwayListener>
+		);
+		expect(container.firstElementChild.tagName).toBe('ARTICLE');
 	});
 
 	it('should take in props to be used like every other elements', () => {
@@ -20,20 +29,6 @@ describe('ClickAway Listener', () => {
 		);
 		expect(getByText(/Hello World/i)).toBeTruthy();
 		expect(getByText(/Hello World/i)).toHaveProperty('style');
-	});
-	it('it should wrap children around the element type specified', () => {
-		const { container } = render(
-			<ClickAwayListener as="article" onClickAway={() => null}>
-				hello best
-			</ClickAwayListener>
-		);
-		expect(container.firstElementChild.tagName).toBe('ARTICLE');
-	});
-	it('it should wrap children around div if no element type is specified', () => {
-		const { container } = render(
-			<ClickAwayListener onClickAway={() => null}>hello best</ClickAwayListener>
-		);
-		expect(container.firstElementChild.tagName).toBe('DIV');
 	});
 
 	it('should trigger onClickAway only when an element is clicked outside', () => {

--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -21,6 +21,20 @@ describe('ClickAway Listener', () => {
 		expect(getByText(/Hello World/i)).toBeTruthy();
 		expect(getByText(/Hello World/i)).toHaveProperty('style');
 	});
+	it('it should wrap children around the element type specified', () => {
+		const { container } = render(
+			<ClickAwayListener Container="article" onClickAway={() => null}>
+				hello best
+			</ClickAwayListener>
+		);
+		expect(container.firstElementChild.tagName).toBe('ARTICLE');
+	});
+	it('it should wrap children around div if no element type is specified', () => {
+		const { container } = render(
+			<ClickAwayListener onClickAway={() => null}>hello best</ClickAwayListener>
+		);
+		expect(container.firstElementChild.tagName).toBe('DIV');
+	});
 
 	it('should trigger onClickAway only when an element is clicked outside', () => {
 		const fakeHandleClick = jest.fn();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,10 +3,11 @@ import React, { useEffect, useRef, FunctionComponent } from 'react';
 type MouseEvents = 'click' | 'mousedown' | 'mouseup';
 type TouchEvents = 'touchstart' | 'touchend';
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {
+interface Props extends React.HTMLAttributes<HTMLElement> {
 	onClickAway: (event: MouseEvent | TouchEvent) => void;
 	mouseEvent?: MouseEvents;
 	touchEvent?: TouchEvents;
+	Container?: React.ElementType;
 }
 
 const ClickAwayListener: FunctionComponent<Props> = ({
@@ -14,9 +15,10 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 	mouseEvent = 'click',
 	touchEvent = 'touchend',
 	children,
+	Container = 'div',
 	...props
 }) => {
-	let node = useRef<HTMLDivElement>(null);
+	let node = useRef<HTMLElement>(null);
 
 	useEffect(() => {
 		const handleEvents = (event: MouseEvent | TouchEvent): void => {
@@ -37,9 +39,9 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 	}, [mouseEvent, onClickAway, touchEvent]);
 
 	return (
-		<div ref={node} {...props}>
+		<Container ref={node} {...props}>
 			{children}
-		</div>
+		</Container>
 	);
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
 	onClickAway: (event: MouseEvent | TouchEvent) => void;
 	mouseEvent?: MouseEvents;
 	touchEvent?: TouchEvents;
-	Container?: React.ElementType;
+	as?: React.ElementType;
 }
 
 const ClickAwayListener: FunctionComponent<Props> = ({
@@ -15,7 +15,7 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 	mouseEvent = 'click',
 	touchEvent = 'touchend',
 	children,
-	Container = 'div',
+	as = 'div',
 	...props
 }) => {
 	let node = useRef<HTMLElement>(null);
@@ -38,11 +38,7 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 		};
 	}, [mouseEvent, onClickAway, touchEvent]);
 
-	return (
-		<Container ref={node} {...props}>
-			{children}
-		</Container>
-	);
+	return React.createElement(as, { ref: node, ...props }, children);
 };
 
 export default ClickAwayListener;


### PR DESCRIPTION
Wraps children around the element type specified in props, defaults to div if no element type is passed.