### PR TITLE
refactor(clickawaylistener): add a default display name for debugging purpose

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -113,4 +113,6 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 	);
 };
 
+ClickAwayListener.displayName = 'ClickAwayListener';
+
 export default ClickAwayListener;


### PR DESCRIPTION
## Current behaviour
ClickAwayListener component shows as Anonymous on React dev tools profiler & components inspector because the component's display is not set.

![image](https://user-images.githubusercontent.com/13041443/119040735-b0b40280-b9ad-11eb-8ae9-68a13553ed1a.png)
![image](https://user-images.githubusercontent.com/13041443/119040983-f5d83480-b9ad-11eb-8c89-ebed55832210.png)

## 🛠 Fix
This PR addresses the issue by setting a default display name for ClickAwayListener component.

