### PR TITLE
feat(events): add support for focusin and focusout events

### DIFF
--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -27,79 +27,118 @@ describe('ClickAway Listener', () => {
 		expect(container.firstElementChild.tagName).toBe('DIV');
 	});
 
-	it('should trigger onClickAway only when an element is clicked outside', () => {
-		const handleClickAway = jest.fn();
-		const { getByText } = render(
-			<React.Fragment>
-				<ClickAwayListener onClickAway={handleClickAway}>
-					<div>Hello World</div>
-				</ClickAwayListener>
-				<button>A button</button>
-				<p>A text element</p>
-			</React.Fragment>
-		);
-		jest.runOnlyPendingTimers();
+	it.each`
+		fireEventFn   | expectedEventType
+		${'focusIn'}  | ${'focusin'}
+		${'click'}    | ${'click'}
+		${'touchEnd'} | ${'touchend'}
+	`(
+		'should return the "$expectedEventType" event object, when the "$fireEventFn" event is fired on the outside element',
+		({ fireEventFn, expectedEventType }) => {
+			const handleClick = (event: FocusEvent | MouseEvent | TouchEvent) => {
+				expect(event.type).toBe(expectedEventType);
+			};
 
-		fireEvent.click(getByText(/A button/i));
-		fireEvent.click(getByText(/A text element/i));
-		fireEvent.click(getByText(/Hello World/i));
-		expect(handleClickAway).toBeCalledTimes(2);
-	});
+			const { getByText } = render(
+				<React.Fragment>
+					<ClickAwayListener onClickAway={handleClick}>
+						<div>An inside Hello World element</div>
+					</ClickAwayListener>
+					<button>An outside button</button>
+				</React.Fragment>
+			);
 
-	it('works with different mouse events', () => {
-		const handleClickAway = jest.fn();
-		const { getByText } = render(
-			<React.Fragment>
-				<ClickAwayListener onClickAway={handleClickAway} mouseEvent="mousedown">
-					<div>Hello World</div>
-				</ClickAwayListener>
-				<button>A button</button>
-				<p>A text element</p>
-			</React.Fragment>
-		);
-		jest.runOnlyPendingTimers();
+			fireEvent[fireEventFn](getByText(/outside button/i));
+		}
+	);
 
-		fireEvent.mouseDown(getByText(/A button/i));
-		fireEvent.mouseDown(getByText(/A text element/i));
-		fireEvent.mouseDown(getByText(/Hello World/i));
-		expect(handleClickAway).toBeCalledTimes(2);
-	});
+	it.each`
+		mouseEvent     | fireEventFn
+		${'click'}     | ${'click'}
+		${'mousedown'} | ${'mouseDown'}
+		${'mouseup'}   | ${'mouseUp'}
+	`(
+		'should invoke the provided onClickAway listener, only when the "$fireEventFn" mouse event is fired on the outside elements',
+		({ mouseEvent, fireEventFn }) => {
+			const handleClickAway = jest.fn();
+			const { getByText } = render(
+				<React.Fragment>
+					<ClickAwayListener
+						onClickAway={handleClickAway}
+						mouseEvent={mouseEvent}
+					>
+						<div>Hello World</div>
+					</ClickAwayListener>
+					<button>A button</button>
+					<p>A text element</p>
+				</React.Fragment>
+			);
+			jest.runOnlyPendingTimers();
 
-	it('returns the event object', () => {
-		const handleClick = (event: MouseEvent | TouchEvent) => {
-			expect(event.type).toBe('click');
-		};
+			fireEvent[fireEventFn](getByText(/A button/i));
+			fireEvent[fireEventFn](getByText(/A text element/i));
+			fireEvent[fireEventFn](getByText(/Hello World/i));
+			expect(handleClickAway).toBeCalledTimes(2);
+		}
+	);
 
-		const { getByText } = render(
-			<React.Fragment>
-				<ClickAwayListener onClickAway={handleClick}>
-					<div>Hello World</div>
-				</ClickAwayListener>
-				<button>A button</button>
-			</React.Fragment>
-		);
+	it.each`
+		touchEvent      | fireEventFn
+		${'touchstart'} | ${'touchStart'}
+		${'touchend'}   | ${'touchEnd'}
+	`(
+		'should invoke the provided onClickAway listener, only when the "$fireEventFn" touch event is fired on the outside elements',
+		({ touchEvent, fireEventFn }) => {
+			const handleClickAway = jest.fn();
+			const { getByText } = render(
+				<React.Fragment>
+					<ClickAwayListener
+						onClickAway={handleClickAway}
+						touchEvent={touchEvent}
+					>
+						<div>Hello World</div>
+					</ClickAwayListener>
+					<button>A button</button>
+					<p>A text element</p>
+				</React.Fragment>
+			);
+			jest.runOnlyPendingTimers();
 
-		fireEvent.click(getByText(/A button/i));
-	});
+			fireEvent[fireEventFn](getByText(/A button/i));
+			fireEvent[fireEventFn](getByText(/A text element/i));
+			fireEvent[fireEventFn](getByText(/Hello World/i));
+			expect(handleClickAway).toBeCalledTimes(2);
+		}
+	);
 
-	it('works with different touch events', () => {
-		const handleClickAway = jest.fn();
-		const { getByText } = render(
-			<React.Fragment>
-				<ClickAwayListener onClickAway={handleClickAway} touchEvent="touchend">
-					<div>Hello World</div>
-				</ClickAwayListener>
-				<button>A button</button>
-				<p>A text element</p>
-			</React.Fragment>
-		);
-		jest.runOnlyPendingTimers();
+	it.each`
+		focusEvent    | fireEventFn
+		${'focusin'}  | ${'focusIn'}
+		${'focusout'} | ${'focusOut'}
+	`(
+		'should invoke the provided onClickAway listener, only when the "$fireEventFn" focus event is fired on the outside elements',
+		({ focusEvent, fireEventFn }) => {
+			const handleClickAway = jest.fn();
+			const { getByText } = render(
+				<React.Fragment>
+					<ClickAwayListener
+						onClickAway={handleClickAway}
+						focusEvent={focusEvent}
+					>
+						<div>Hello World</div>
+					</ClickAwayListener>
+					<button>A button</button>
+					<p>A text element</p>
+				</React.Fragment>
+			);
+			jest.runOnlyPendingTimers();
 
-		fireEvent.touchEnd(getByText(/A button/i));
-		fireEvent.touchEnd(getByText(/A text element/i));
-		fireEvent.touchEnd(getByText(/Hello World/i));
-		expect(handleClickAway).toBeCalledTimes(2);
-	});
+			fireEvent[fireEventFn](getByText(/A button/i));
+			fireEvent[fireEventFn](getByText(/A text element/i));
+			fireEvent[fireEventFn](getByText(/Hello World/i));
+			expect(handleClickAway).toBeCalledTimes(2);
+		}
+	);
 
 	it('should handle multiple cases', () => {
 		const handleClickAway = jest.fn();
@@ -144,7 +183,7 @@ describe('ClickAway Listener', () => {
 	});
 	Input.displayName = 'Input';
 
-	it('should not replace previously added refs', () => {
+	it('shouldn’t replace previously added refs', () => {
 		const { result } = renderHook(() => {
 			const ref = React.useRef();
 
@@ -179,7 +218,7 @@ describe('ClickAway Listener', () => {
 		expect(result.current.ref).toStrictEqual(inputRef);
 	});
 
-	it("shouldn't hijack the onClick listener", () => {
+	it('shouldn’t hijack the onClick listener', () => {
 		const handleClick = jest.fn();
 		const handleClickAway = jest.fn();
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,11 +9,14 @@ import React, {
 	FunctionComponent
 } from 'react';
 
+type FocusEvents = 'focusin' | 'focusout';
 type MouseEvents = 'click' | 'mousedown' | 'mouseup';
 type TouchEvents = 'touchstart' | 'touchend';
-type Events = MouseEvent | TouchEvent;
+type Events = FocusEvent | MouseEvent | TouchEvent;
+
 interface Props extends HTMLAttributes<HTMLElement> {
 	onClickAway: (event: Events) => void;
+	focusEvent?: FocusEvents;
 	mouseEvent?: MouseEvents;
 	touchEvent?: TouchEvents;
 	children: ReactElement<any>;
@@ -21,6 +24,8 @@ interface Props extends HTMLAttributes<HTMLElement> {
 
 const eventTypeMapping = {
 	click: 'onClick',
+	focusin: 'onFocus',
+	focusout: 'onFocus',
 	mousedown: 'onMouseDown',
 	mouseup: 'onMouseUp',
 	touchstart: 'onTouchStart',
@@ -30,6 +35,7 @@ const eventTypeMapping = {
 const ClickAwayListener: FunctionComponent<Props> = ({
 	children,
 	onClickAway,
+	focusEvent = 'focusin',
 	mouseEvent = 'click',
 	touchEvent = 'touchend'
 }) => {
@@ -94,19 +100,23 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 
 		document.addEventListener(mouseEvent, handleEvents);
 		document.addEventListener(touchEvent, handleEvents);
+		document.addEventListener(focusEvent, handleEvents);
 
 		return () => {
 			document.removeEventListener(mouseEvent, handleEvents);
 			document.removeEventListener(touchEvent, handleEvents);
+			document.removeEventListener(focusEvent, handleEvents);
 		};
-	}, [mouseEvent, onClickAway, touchEvent]);
+	}, [focusEvent, mouseEvent, onClickAway, touchEvent]);
 
 	const mappedMouseEvent = eventTypeMapping[mouseEvent];
 	const mappedTouchEvent = eventTypeMapping[touchEvent];
+	const mappedFocusEvent = eventTypeMapping[focusEvent];
 
 	return React.Children.only(
 		cloneElement(children as ReactElement<any>, {
 			ref: handleChildRef,
+			[mappedFocusEvent]: handleBubbledEvents(mappedFocusEvent),
 			[mappedMouseEvent]: handleBubbledEvents(mappedMouseEvent),
 			[mappedTouchEvent]: handleBubbledEvents(mappedTouchEvent)
 		})


### PR DESCRIPTION
## Summary

For accessibility purposes, we should also invoke the `onClickAway` listener when the user focuses
on an outside element. This PR adds support for the `focusin` and `focusout` DOM events. React
internally maps them to the `onFocus` handler.

There was no test coverage for some of the events e.g. `touchstart`. I’ve refactored the tests to use [Jest’s `each` table feature](https://jestjs.io/docs/api#1-testeachtablename-fn-timeout). Now, all events are covered with unit tests.

## Testing

### Before

https://codesandbox.io/s/clickawaylistener-example-without-focus-support-qjsp3?file=/src/index.js

### After

https://codesandbox.io/s/clickawaylistener-example-with-focus-events-support-iqpfp?file=/src/index.js