### PR TITLE
Improve readme with formatting and caveats example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,47 @@ const App = () => {
 };
 ```
 
-Caveats:
- - Ensure the ClickAway component has just one child else `React.only` will throw an error.
- - It doesn't work with Text nodes.
+### Caveats
+
+[v2.0.0](https://github.com/ooade/react-click-away-listener/releases/tag/v2.0.0) has breaking changes which uses the [`React.Children.only`](https://reactjs.org/docs/react-api.html#reactchildrenonly) API.
+
+Thus, the following caveats apply for the `children` of the `<ClickAwayListener>` component:
+
+1. You may pass **only one child** to the `<ClickAwayListener>` component.
+2. You may not pass plain text nodes to the `<ClickAwayListener>` component.
+
+Violating the above caveats will result in the following error:
+
+```js
+Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
+
+Check the render method of `ClickAwayListener`.
+```
+
+If you have multiple children components to pass, you can simply pass a [React Fragment](https://reactjs.org/docs/fragments.html) like so:
+
+```jsx
+// Assume the `handleClickAway` function is defined.
+<ClickAwayListener onClickAway={handleClickAway}>
+  <>
+    <p>First paragraph</p>
+    <button>Example Button</button>
+    <p>Second paragraph</p>
+  </>
+</ClickAwayListener>
+```
+
+Or if you only have text nodes, you can simply wrap them in a [React Fragment](https://reactjs.org/docs/fragments.html) like so:
+
+```jsx
+// Assume the `handleClickAway` function is defined.
+<ClickAwayListener onClickAway={handleClickAway}>
+  <>
+    First text node
+    Second text node
+  </>
+</ClickAwayListener>
+```
 
 ## Props
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Error: Element type is invalid: expected a string (for built-in components) or a
 Check the render method of `ClickAwayListener`.
 ```
 
-If you have multiple children components to pass, you can simply pass a [React Fragment](https://reactjs.org/docs/fragments.html) like so:
+If you have multiple child components to pass, you can simply wrap them around a [React Fragment](https://reactjs.org/docs/fragments.html) like so:
 
 ```jsx
 // Assume the `handleClickAway` function is defined.
@@ -74,7 +74,7 @@ If you have multiple children components to pass, you can simply pass a [React F
 </ClickAwayListener>
 ```
 
-Or if you only have text nodes, you can simply wrap them in a [React Fragment](https://reactjs.org/docs/fragments.html) like so:
+Or if you only have text nodes, you can also wrap them in a [React Fragment](https://reactjs.org/docs/fragments.html) like so:
 
 ```jsx
 // Assume the `handleClickAway` function is defined.
@@ -93,6 +93,7 @@ Or if you only have text nodes, you can simply wrap them in a [React Fragment](h
 | onClickAway | (event) => void                   |               | Fires when a user clicks outside the click away component |
 | mouseEvent  | 'click' \|<br/>'mousedown' \|<br/>'mouseup'| 'click'     | The mouse event type that gets fired on ClickAway          |
 | touchEvent  | 'touchstart' \|<br/>'touchend'         | 'touchend'  | The touch event type that gets fired on ClickAway          |
+| focusEvent  | 'focusin' \|<br/>'focusout'       | 'focusin'        | The focus event type that gets fired on ClickAway      |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
 yarn add react-click-away-listener
 ```
 
-- It's quite small in size.
-- It's built with TypeScript.
-- It works with Portals (>= v2).
-- It supports Mouse, Touch and Focus Events.
+- It's quite **small** in size! Just [![Bundlephobia](https://img.shields.io/bundlephobia/min/react-click-away-listener.svg?style=flat-square&label "Bundle size (minified)")](https://bundlephobia.com/result?p=react-click-away-listener) minified, or [![Bundlephobia](https://img.shields.io/bundlephobia/minzip/react-click-away-listener.svg?style=flat-square&label "Bundle size (minified+gzipped)")](https://bundlephobia.com/result?p=react-click-away-listener) minified & gzipp’d.
+- It's built with **TypeScript**.
+- It works with [React Portals](https://reactjs.org/docs/portals.html) ([v2.0.0](https://github.com/ooade/react-click-away-listener/releases/tag/v2.0.0) onwards).
+- It supports **mouse**, **touch** and **focus** events.
 
 ## Usage
 


### PR DESCRIPTION
I actually spend a lot of time trying to debug the breaking change introduced in [v2.0.0](https://github.com/ooade/react-click-away-listener/releases/tag/v2.0.0):

```
Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

Check the render method of `ClickAwayListener`.
```

That why, I think adding it in the `README.md` will be valuable to others.