### PR TITLE
Support rendering in external documents

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -84,13 +84,15 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 	};
 
 	useEffect(() => {
+		const nodeDocument = node.current?.ownerDocument ?? document;
+
 		const handleEvents = (event: Events): void => {
 			if (!mountedRef.current) return;
 
 			if (
 				(node.current && node.current.contains(event.target as Node)) ||
 				bubbledEventTarget.current === event.target ||
-				!document.contains(event.target as Node)
+				!nodeDocument.contains(event.target as Node)
 			) {
 				return;
 			}
@@ -98,14 +100,14 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 			onClickAway(event);
 		};
 
-		document.addEventListener(mouseEvent, handleEvents);
-		document.addEventListener(touchEvent, handleEvents);
-		document.addEventListener(focusEvent, handleEvents);
+		nodeDocument.addEventListener(mouseEvent, handleEvents);
+		nodeDocument.addEventListener(touchEvent, handleEvents);
+		nodeDocument.addEventListener(focusEvent, handleEvents);
 
 		return () => {
-			document.removeEventListener(mouseEvent, handleEvents);
-			document.removeEventListener(touchEvent, handleEvents);
-			document.removeEventListener(focusEvent, handleEvents);
+			nodeDocument.removeEventListener(mouseEvent, handleEvents);
+			nodeDocument.removeEventListener(touchEvent, handleEvents);
+			nodeDocument.removeEventListener(focusEvent, handleEvents);
 		};
 	}, [focusEvent, mouseEvent, onClickAway, touchEvent]);
 


### PR DESCRIPTION
In our project we have complex UI and support ejecting it into popup windows with help of portals. `react-click-away-listener` is not working in such windows because it attaches to events of the document of the initial window, not opened window.

To reproduce:
- open an external window `const externalWindow = window.open('', '', 'popup');`
- render `react-click-away-listener` into it:
```tsx
createPortal(
  <ClickAwayListener onClickAway={() => console.log('CLICKED AWAY')}>
    <div>Menu</div>
  </ClickAwayListener>,
  externalWindow.document.body
)
```
- `onClickAway` is executed when clicking in the initial window. Clicking on the external window, that actually carries the UI, does nothing.

Demo: https://stackblitz.com/edit/react-playground-practice-y194rs?file=index.js

This PR fixes the issue