### PR TITLE
chore(workflows): use action from my personal repo

### DIFF
--- a/.github/workflows/report-coverage.yml
+++ b/.github/workflows/report-coverage.yml
@@ -15,6 +15,6 @@ jobs:
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn run coverage
-      - uses: coverallsapp/github-action@master
+      - uses: ooade/coverallsapp-github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The main coverallsapp action hasn't been maintained for a while, so this PR references the fork I created.