### PR TITLE
Revert "chore(workflows): use action from my personal repo"

### DIFF
--- a/.github/workflows/report-coverage.yml
+++ b/.github/workflows/report-coverage.yml
@@ -15,6 +15,6 @@ jobs:
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn run coverage
-      - uses: ooade/coverallsapp-github-action@master
+      - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This Reverts ooade/react-click-away-listener#75 as they've finally made the change to use node v16.