### PR TITLE
feat: support React 19 and update focusout event mapping to onBlur 👌

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,8 +42,8 @@
 				"typescript": "^5.5.4"
 			},
 			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,12 +26,14 @@ interface Props extends HTMLAttributes<HTMLElement> {
 const eventTypeMapping = {
 	click: 'onClick',
 	focusin: 'onFocus',
-	focusout: 'onFocus',
+	focusout: 'onBlur',
 	mousedown: 'onMouseDown',
 	mouseup: 'onMouseUp',
 	touchstart: 'onTouchStart',
 	touchend: 'onTouchEnd'
 };
+
+const reactMajorVersion = parseInt(React.version.split('.')[0], 10);
 
 const mergeRefs = <T extends any>(
 	refs: Array<Ref<T> | undefined | null>
@@ -46,8 +48,6 @@ const mergeRefs = <T extends any>(
 		});
 	};
 };
-
-const reactMajorVersion = parseInt(React.version.split('.')[0], 10);
 
 const ClickAwayListener: FunctionComponent<Props> = ({
 	children,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,6 +33,8 @@ const eventTypeMapping = {
 	touchend: 'onTouchEnd'
 };
 
+const reactMajorVersion = parseInt(React.version.split('.')[0], 10);
+
 function useForkRef<T = any>(
 	...refs: Array<Ref<T> | undefined>
 ): RefCallback<T> {
@@ -88,6 +90,10 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 		node.current = ref;
 	}, (children as any).ref);
 
+	const handleReact19ChildRef = (instance: HTMLElement | null) => {
+		node.current = instance;
+	};
+
 	useEffect(() => {
 		const nodeDocument = node.current?.ownerDocument ?? document;
 
@@ -122,7 +128,7 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 
 	return React.Children.only(
 		cloneElement(children as ReactElement<any>, {
-			ref: combinedRef,
+			ref: reactMajorVersion >= 19 ? handleReact19ChildRef : combinedRef,
 			[mappedFocusEvent]: handleBubbledEvents(mappedFocusEvent),
 			[mappedMouseEvent]: handleBubbledEvents(mappedMouseEvent),
 			[mappedTouchEvent]: handleBubbledEvents(mappedTouchEvent)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,7 +54,8 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 	onClickAway,
 	focusEvent = 'focusin',
 	mouseEvent = 'click',
-	touchEvent = 'touchend'
+	touchEvent = 'touchend',
+	...rest
 }) => {
 	const node = useRef<HTMLElement | null>(null);
 	const bubbledEventTarget = useRef<EventTarget | null>(null);
@@ -135,7 +136,8 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 			ref: combinedRef,
 			[mappedFocusEvent]: handleBubbledEvents(mappedFocusEvent),
 			[mappedMouseEvent]: handleBubbledEvents(mappedMouseEvent),
-			[mappedTouchEvent]: handleBubbledEvents(mappedTouchEvent)
+			[mappedTouchEvent]: handleBubbledEvents(mappedTouchEvent),
+			...rest
 		})
 	);
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,22 +33,21 @@ const eventTypeMapping = {
 	touchend: 'onTouchEnd'
 };
 
-const reactMajorVersion = parseInt(React.version.split('.')[0], 10);
-console.log({ reactMajorVersion });
-
-function useForkRef<T = any>(
-	...refs: Array<Ref<T> | undefined>
-): RefCallback<T> {
-	return (node: T) => {
+const mergeRefs = <T extends any>(
+	refs: Array<Ref<T> | undefined | null>
+): RefCallback<T> => {
+	return (value) => {
 		refs.forEach((ref) => {
 			if (typeof ref === 'function') {
-				ref(node);
-			} else if (ref != null && typeof ref === 'object') {
-				(ref as MutableRefObject<T | null>).current = node;
+				ref(value);
+			} else if (ref != null) {
+				(ref as MutableRefObject<T | null>).current = value;
 			}
 		});
 	};
-}
+};
+
+const reactMajorVersion = parseInt(React.version.split('.')[0], 10);
 
 const ClickAwayListener: FunctionComponent<Props> = ({
 	children,
@@ -87,13 +86,17 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 			}
 		};
 
-	const combinedRef = useForkRef((ref) => {
-		node.current = ref;
-	}, (children as any).ref);
+	let childRef: React.Ref<any> | null = null;
 
-	const handleReact19ChildRef = (instance: HTMLElement | null) => {
-		node.current = instance;
-	};
+	// For React 19+, we get the ref via props.ref
+	if (reactMajorVersion >= 19) {
+		childRef = children.props?.ref || null;
+	} else if ('ref' in children) {
+		childRef = (children as any).ref;
+	}
+
+	// Create a combined ref handler
+	const combinedRef = mergeRefs([node, childRef]);
 
 	useEffect(() => {
 		const nodeDocument = node.current?.ownerDocument ?? document;
@@ -129,7 +132,7 @@ const ClickAwayListener: FunctionComponent<Props> = ({
 
 	return React.Children.only(
 		cloneElement(children as ReactElement<any>, {
-			ref: reactMajorVersion >= 19 ? handleReact19ChildRef : combinedRef,
+			ref: combinedRef,
 			[mappedFocusEvent]: handleBubbledEvents(mappedFocusEvent),
 			[mappedMouseEvent]: handleBubbledEvents(mappedMouseEvent),
 			[mappedTouchEvent]: handleBubbledEvents(mappedTouchEvent)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,6 +34,7 @@ const eventTypeMapping = {
 };
 
 const reactMajorVersion = parseInt(React.version.split('.')[0], 10);
+console.log({ reactMajorVersion });
 
 function useForkRef<T = any>(
 	...refs: Array<Ref<T> | undefined>


### PR DESCRIPTION
This PR does the following:
- Add support for React 19 as described in #95  
- [Breaking Change] Map focusout event to onBlur
- Gather and pass down other props 👌

