### PR TITLE
fix: add .d.mts for ESM TypeScript support (#117)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"exports": {
 		".": {
 			"import": {
-				"types": "./dist/index.d.ts",
+				"types": "./dist/index.d.mts",
 				"default": "./dist/index.mjs"
 			},
 			"require": {
@@ -22,7 +22,7 @@
 		"lint": "eslint src/*",
 		"coverage": "jest --coverage",
 		"prepublishOnly": "npm run build",
-		"build": "rm -rf dist && rollup -c rollup.config.mjs",
+		"build": "rm -rf dist && rollup -c rollup.config.mjs && cp dist/index.d.ts dist/index.d.mts",
 		"semantic-release": "semantic-release",
 		"prettier": "prettier --write '{src,__tests__}/*.tsx'",
 		"prepare": "husky"


### PR DESCRIPTION
Fixes #117                                                                                                                                     

Without a .d.mts file, TypeScript treats our types as CJS in ESM projects, breaking usage.